### PR TITLE
Add no-op SSE on GET /mcp + fix lefthook in worktrees

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -20,7 +20,7 @@ commit-msg:
   commands:
     conventional:
       run: |
-        msg=$(head -1 .git/COMMIT_EDITMSG)
+        msg=$(head -1 {1})
         # Allow release commits from release.sh
         if echo "$msg" | grep -qE '^release: v[0-9]+\.[0-9]+\.[0-9]+$'; then
           exit 0

--- a/wimg-sync/src/index.ts
+++ b/wimg-sync/src/index.ts
@@ -109,8 +109,28 @@ function getMcpSession(env: Bindings, key: string) {
   return env.MCP_SESSION.get(id);
 }
 
-// MCP: SSE not supported — reject GET
-app.get("/mcp", (c) => c.text("Method Not Allowed", 405));
+// MCP: GET opens a no-op SSE stream. Responses come back on POST directly,
+// but clients (Jan, mcp-remote) require the stream to exist per Streamable HTTP spec.
+app.get("/mcp", (c) => {
+  const syncKey = extractBearerToken(c.req.header("Authorization"));
+  if (!syncKey) {
+    return c.text("Missing Authorization", 401);
+  }
+
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(": connected\n\n"));
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    },
+  });
+});
 
 // MCP JSON-RPC endpoint (Streamable HTTP transport)
 app.post("/mcp", async (c) => {


### PR DESCRIPTION
## Summary

- **`feat`**: Open an idle SSE stream on `GET /mcp` instead of returning 405. Streamable HTTP clients (Jan, `mcp-remote`) treat the missing GET channel as a closed transport even when POST RPC succeeds. Actual JSON-RPC responses still flow over POST — this just satisfies the spec's optional GET-with-SSE endpoint so clients keep the connection alive.
- **`fix`**: `lefthook.yml` commit-msg hook now uses `{1}` (the path lefthook passes in) instead of the hardcoded `.git/COMMIT_EDITMSG`. The hardcoded path breaks in git worktrees where `.git` is a file pointing at the real gitdir, causing every commit to fail with `head: .git/COMMIT_EDITMSG: Not a directory`.

## Background

Surfaced while debugging Jan AI's MCP support. Wrangler logs showed POST `/mcp` returning 200 (initialize, tools/list all working), but `GET /mcp` returning 405. Jan kept reporting "Transport closed" because it depends on the SSE channel existing per the Streamable HTTP spec, even if no server-initiated messages flow through it. Claude Desktop sidesteps this because `mcp-remote` bridges stdio↔HTTP and doesn't surface the missing GET to the host.

This is Fix B from a few options — the minimum viable, spec-compliant change. If a client genuinely needs server-pushed messages on the SSE stream (none observed yet), that would require routing the GET into `McpSession` DO and forwarding events, which is meaningfully more work.

## Test plan

- [ ] `curl -i -N -H "Authorization: Bearer <key>" http://localhost:8787/mcp` returns `200`, `Content-Type: text/event-stream`, and a `: connected` line; connection stays open until Ctrl+C
- [ ] Existing POST `/mcp` flow still works (Claude Desktop / `mcp-remote` initialize → tools/list → tool call)
- [ ] Missing `Authorization` header on GET returns 401
- [ ] Commits succeed in git worktrees (Conductor) and in single-tree clones